### PR TITLE
Refactor Yahtzee Scoring

### DIFF
--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -17,12 +17,12 @@ class YahtzeeScoring
     best_score = 0
 
     categories = [
-      score_three_of_a_kind(roll),
-      score_four_of_a_kind(roll),
-      score_full_house(roll),
-      score_small_straight(roll),
-      score_large_straight(roll),
       score_yahtzee(roll),
+      score_large_straight(roll),
+      score_small_straight(roll),
+      score_full_house(roll),
+      score_four_of_a_kind(roll),
+      score_three_of_a_kind(roll),
       score_chance(roll)
     ]
 

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -3,12 +3,6 @@ class YahtzeeScoring
     best_category = nil
     best_score = 0
 
-    score = score_upper_section(roll)
-    if score[:score] > best_score
-      best_score = score[:score]
-      best_category = score[:category]
-    end
-
     score = score_lower_section(roll)
     if score[:score] > best_score
       best_score = score[:score]
@@ -16,24 +10,6 @@ class YahtzeeScoring
     end
 
     { category: best_category, score: best_score }
-  end
-
-  def self.score_upper_section(roll)
-    best_category = nil
-    best_score = 0
-
-    (1..6).each do |num|
-      score = roll.count(num) * num
-      if score > best_score
-        best_score = score
-        best_category = num_to_category(num)
-      end
-    end
-    { category: best_category, score: best_score }
-  end
-
-  def self.num_to_category(num)
-    { 1 => :ones, 2 => :twos, 3 => :threes, 4 => :fours, 5 => :fives, 6 => :sixes }[num]
   end
 
   def self.score_lower_section(roll)

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,80 +1,41 @@
 class YahtzeeScoring
   def self.best_score(roll)
-    best_category = nil
-    best_score = 0
+    frequencies = roll.tally
+    sum = roll.sum
 
-    score = score_lower_section(roll)
-    if score[:score] > best_score
-      best_score = score[:score]
-      best_category = score[:category]
+    # Yahtzee
+    if frequencies.keys.length == 1
+      return { category: :yahtzee, score: 50 }
     end
 
-    { category: best_category, score: best_score }
-  end
-
-  def self.score_lower_section(roll)
-    best_category = nil
-    best_score = 0
-
-    categories = [
-      score_yahtzee(roll),
-      score_large_straight(roll),
-      score_small_straight(roll),
-      score_full_house(roll),
-      score_four_of_a_kind(roll),
-      score_three_of_a_kind(roll),
-      score_chance(roll)
-    ]
-
-    categories.each do |result|
-      if result[:score] > best_score
-        best_score = result[:score]
-        best_category = result[:category]
-      end
+    # Large straight
+    sorted_keys = frequencies.keys.sort
+    if sorted_keys == [1, 2, 3, 4, 5] || sorted_keys == [2, 3, 4, 5, 6]
+      return { category: :large_straight, score: 40 }
     end
 
-    { category: best_category, score: best_score }
-  end
-
-  def self.score_three_of_a_kind(roll)
-    roll.each do |num|
-      return { category: :three_of_a_kind, score: roll.sum } if roll.count(num) >= 3
-    end
-    { category: nil, score: 0 }
-  end
-
-  def self.score_four_of_a_kind(roll)
-    roll.each do |num|
-      return { category: :four_of_a_kind, score: roll.sum } if roll.count(num) >= 4
-    end
-    { category: nil, score: 0 }
-  end
-
-  def self.score_full_house(roll)
-    counts = roll.tally.values.sort
-    return { category: :full_house, score: 25 } if counts == [2, 3]
-    { category: nil, score: 0 }
-  end
-
-  def self.score_small_straight(roll)
-    unique_sorted = roll.uniq.sort
+    # Small straight
     straights = [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
-    return { category: :small_straight, score: 30 } if straights.any? { |s| (s - unique_sorted).empty? }
-    { category: nil, score: 0 }
-  end
+    if straights.any? { |straight| straight.all? { |num| frequencies.key?(num) } }
+      return { category: :small_straight, score: 30 }
+    end
 
-  def self.score_large_straight(roll)
-    unique_sorted = roll.uniq.sort
-    return { category: :large_straight, score: 40 } if unique_sorted == [1, 2, 3, 4, 5] || unique_sorted == [2, 3, 4, 5, 6]
-    { category: nil, score: 0 }
-  end
+    # Full house
+    if frequencies.values.sort == [2, 3]
+      return { category: :full_house, score: 25 }
+    end
 
-  def self.score_yahtzee(roll)
-    return { category: :yahtzee, score: 50 } if roll.uniq.length == 1
-    { category: nil, score: 0 }
-  end
+    # Four of a kind
+    if frequencies.values.include?(4)
+      return { category: :four_of_a_kind, score: sum }
+    end
 
-  def self.score_chance(roll)
-    { category: :chance, score: roll.sum }
+    # Three of a kind
+    if frequencies.values.include?(3)
+      return { category: :three_of_a_kind, score: sum }
+    end
+
+    # If no other category matches, score as chance
+    { category: :chance, score: sum }
   end
 end

--- a/yahtzee_scoring_test.rb
+++ b/yahtzee_scoring_test.rb
@@ -44,9 +44,9 @@ class TestYahtzeeScoring < Minitest::Test
     assert_equal({ category: :chance, score: 17 }, YahtzeeScoring.best_score([1, 2, 3, 5, 6]))
   end
 
-  # Test that the best scoring category is always selected
+  # Test that the best scoring category is always selected when a roll matches multiple categories
   def test_best_scoring_category_is_selected
-    # Yahtzee beats everything
+    # Yahtzee beats three or four of a kind
     assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([5, 5, 5, 5, 5]))
 
     # Large straight beats small straight

--- a/yahtzee_scoring_test.rb
+++ b/yahtzee_scoring_test.rb
@@ -2,6 +2,7 @@ require "minitest/autorun"
 require_relative "yahtzee_scoring"
 
 class TestYahtzeeScoring < Minitest::Test
+  # Original test to make sure no regressions are introduced
   def test_best_score
     assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([6, 6, 6, 6, 6]))
     assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([2, 3, 4, 5, 6]))
@@ -9,4 +10,82 @@ class TestYahtzeeScoring < Minitest::Test
     assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([3, 3, 3, 5, 5]))
     assert_equal({ category: :chance, score: 17 }, YahtzeeScoring.best_score([1, 2, 3, 5, 6]))
   end
+
+  # == Lower Section Tests ==
+  def test_three_of_a_kind
+    assert_equal({ category: :three_of_a_kind, score: 21 }, YahtzeeScoring.best_score([6, 6, 6, 2, 1]))
+  end
+
+  def test_four_of_a_kind
+    assert_equal({ category: :four_of_a_kind, score: 21 }, YahtzeeScoring.best_score([5, 5, 5, 5, 1]))
+  end
+
+  def test_full_house
+    assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([3, 3, 3, 5, 5]))
+  end
+
+  def test_small_straight
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([1, 2, 3, 4, 6]))
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([2, 3, 4, 5, 5]))
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([3, 3, 4, 5, 6]))
+  end
+
+  def test_large_straight
+    assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([2, 3, 4, 5, 6]))
+    assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([1, 2, 3, 4, 5]))
+  end
+
+  def test_yahtzee
+    assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([6, 6, 6, 6, 6]))
+    assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([1, 1, 1, 1, 1]))
+  end
+
+  def test_chance
+    assert_equal({ category: :chance, score: 17 }, YahtzeeScoring.best_score([1, 2, 3, 5, 6]))
+  end
+
+  # Test that the best scoring category is always selected
+  def test_best_scoring_category_is_selected
+    # Yahtzee beats everything
+    assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([5, 5, 5, 5, 5]))
+
+    # Large straight beats small straight
+    assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([1, 2, 3, 4, 5]))
+
+    # Full house beats three of a kind
+    assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([2, 2, 4, 4, 4]))
+  end
+
+  # I tried to write scenarios for each category but if we always return the highest scoring category,
+  # we never actually return anything from the upper section. In all these examples, `chance`
+  # is a higher scoring category because it includes all dice and not just the matching numbers.
+  # If I added another matching number to any example, `three_of_a_kind` would be the highest scoring category.
+
+  # This is an area where we could extend the funcitionality to allow the user to choose from any available category
+  # that matches the current roll. This aligns more with real-life Yahtzee play but is out of scope for this exercise.
+
+  # == Upper Section Tests ==
+  # def test_ones
+  #   assert_equal({ category: :ones, score: 2 }, YahtzeeScoring.best_score([1, 1, 2, 3, 5]))
+  # end
+
+  # def test_twos
+  #   assert_equal({ category: :twos, score: 4 }, YahtzeeScoring.best_score([2, 2, 5, 1, 3]))
+  # end
+
+  # def test_threes
+  #   assert_equal({ category: :threes, score: 6 }, YahtzeeScoring.best_score([3, 3, 5, 1, 2]))
+  # end
+
+  # def test_fours
+  #   assert_equal({ category: :fours, score: 8 }, YahtzeeScoring.best_score([4, 4, 5, 1, 2]))
+  # end
+
+  # def test_fives
+  #   assert_equal({ category: :fives, score: 10 }, YahtzeeScoring.best_score([5, 5, 6, 1, 2]))
+  # end
+
+  # def test_sixes
+  #   assert_equal({ category: :sixes, score: 12 }, YahtzeeScoring.best_score([6, 6, 5, 1, 2]))
+  # end
 end

--- a/yahtzee_scoring_test.rb
+++ b/yahtzee_scoring_test.rb
@@ -55,37 +55,4 @@ class TestYahtzeeScoring < Minitest::Test
     # Full house beats three of a kind
     assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([2, 2, 4, 4, 4]))
   end
-
-  # I tried to write scenarios for each category but if we always return the highest scoring category,
-  # we never actually return anything from the upper section. In all these examples, `chance`
-  # is a higher scoring category because it includes all dice and not just the matching numbers.
-  # If I added another matching number to any example, `three_of_a_kind` would be the highest scoring category.
-
-  # This is an area where we could extend the funcitionality to allow the user to choose from any available category
-  # that matches the current roll. This aligns more with real-life Yahtzee play but is out of scope for this exercise.
-
-  # == Upper Section Tests ==
-  # def test_ones
-  #   assert_equal({ category: :ones, score: 2 }, YahtzeeScoring.best_score([1, 1, 2, 3, 5]))
-  # end
-
-  # def test_twos
-  #   assert_equal({ category: :twos, score: 4 }, YahtzeeScoring.best_score([2, 2, 5, 1, 3]))
-  # end
-
-  # def test_threes
-  #   assert_equal({ category: :threes, score: 6 }, YahtzeeScoring.best_score([3, 3, 5, 1, 2]))
-  # end
-
-  # def test_fours
-  #   assert_equal({ category: :fours, score: 8 }, YahtzeeScoring.best_score([4, 4, 5, 1, 2]))
-  # end
-
-  # def test_fives
-  #   assert_equal({ category: :fives, score: 10 }, YahtzeeScoring.best_score([5, 5, 6, 1, 2]))
-  # end
-
-  # def test_sixes
-  #   assert_equal({ category: :sixes, score: 12 }, YahtzeeScoring.best_score([6, 6, 5, 1, 2]))
-  # end
 end


### PR DESCRIPTION
This pull request refactors the `YahtzeeScoring` class to simplify the scoring logic and updates the corresponding tests in `yahtzee_scoring_test.rb` to ensure coverage of all applicable cases.

Refactoring of scoring logic:

* Consolidated all scoring methods into the `best_score` method, removing redundant methods and simplifying the logic for determining the best score.
    * This class only handles one set of dice at a time, and there is no combination of dice that results in an "Upper Section" score being returned. Let's use 6 as an example, since it's the highest possible number found on a die and so has the best chance of scoring high enough to compete with the larger scores in the "Bottom Section."
    * 6 x 5 = 30 in the "Sixes" category but would be better scored as "Yahtzee" for 50 points.
    * 6 x 4 = 24 in the "Sixes" category but would be better scored as "Four of a Kind" for a minimum of 25 points.
    * 6 x 3 = 18 in the "Sixes" category but would be better scored as "Three of a Kind" for 20 points.
* Because the "Bottom Section" scores are higher and/or include more of the dice in their scoring, we will never return an "Upper Section" score.

* We also now return early out of the method as soon as one of the scoring conditions is met, rather than continuing to evaluate all possible scores. By ordering the scores from highest to lowest, we can ensure that the first met condition is always the highest possible score for a given roll. We also reduce the number of comparisons needed to determine the best score, which can improve performance for any roll that has a higher scoring category than "Chance."

Updates to tests:

* Added new tests to cover all scoring categories, ensuring that the `best_score` method correctly identifies the highest scoring category for a given roll.
    * Some of these examples could be scored in multiple categories, so we want to show that we are always returning the highest possible score and category.